### PR TITLE
Add a shuffle button to settings panel

### DIFF
--- a/source/javascripts/timer.js
+++ b/source/javascripts/timer.js
@@ -55,6 +55,7 @@ pages.timer = pages.timer || (function() {
         mobsterContainer = $('.mobster-container');
         pageTitle = $('title');
         saveLink = $('.save-settings');
+        shuffleMobstersLink = $('.shuffle-mobsters');
 
         turnText = $('.turn-text');
 
@@ -62,6 +63,7 @@ pages.timer = pages.timer || (function() {
         currentMobsterIndex = 0;
 
         saveLink.bind('click', reloadWithSettings);
+        shuffleMobstersLink.bind('click', shuffleMobsters);
 
         counter.bind('click', function onClick() {
             if(state === State.STOPPED) {
@@ -188,6 +190,18 @@ pages.timer = pages.timer || (function() {
 
         mobsters.push(mobster);
         mobsterContainer.append(mobster.root);
+    }
+
+    function shuffleMobsters() {
+        // Adapted from https://stackoverflow.com/a/12646864/108511
+        for (var i = mobsters.length - 1; i > 0; i--) {
+          var j = Math.floor(Math.random() * (i + 1));
+          var temp = mobsters[i];
+          mobsters[i] = mobsters[j];
+          mobsters[j] = temp;
+        }
+
+        reloadWithSettings();
     }
 
     function parsePeriodInput() {

--- a/source/stylesheets/main.scss
+++ b/source/stylesheets/main.scss
@@ -127,6 +127,10 @@ body {
     line-height:33px;
 }
 
+.reveal-modal a:not(.close-reveal-modal) {
+    margin-right: 20px;
+}
+
 @-moz-keyframes spin {
     from { -moz-transform: rotate(0deg); }
     to { -moz-transform: rotate(360deg); }

--- a/source/timer.html.haml
+++ b/source/timer.html.haml
@@ -45,3 +45,4 @@ header:
   %a.close-reveal-modal &#215;
 
   %a.save-settings{ title: "Page reloads with settings in the querystring, save or share using your browser" }  Save
+  %a.shuffle-mobsters{ title: "Page reloads with shuffled mobsters" }  Shuffle


### PR DESCRIPTION
We shuffle our mobsters every morning to make sure everyone has a chance to navigate different people.

This PR adds a shuffle button that shuffles the `mobsters` array using the [Durstenfeld shuffle](https://stackoverflow.com/a/12646864/108511) before triggering `reloadWithSettings()`

I'm not super happy with the page reload, but it was the easiest option since there's no function to destroy and rerender the `.mobster-container`. It might be worth rerendering the UI on state changes and rewriting these operations to not modify the UI directly (which would avoid state desync issues in addition to making this feature a bit cleaner), though I've not implemented this since I'm unsure if it'd match the project's future development.